### PR TITLE
fix: use new subdomain for requests

### DIFF
--- a/src/backpack-tf.ts
+++ b/src/backpack-tf.ts
@@ -104,7 +104,7 @@ export class BackpackTFAPI {
     if (Array.isArray(payload) || (as === 'data' && authAs !== 'append')) {
       return this.requestClient.send<T>({
         method,
-        url: `https://backpack.tf/api/${path}`,
+        url: `https://api.backpack.tf/api/${path}`,
         data: payload,
         params: authStore,
       });
@@ -113,7 +113,7 @@ export class BackpackTFAPI {
     if (authAs === 'append') {
       return this.requestClient.send<T>({
         method,
-        url: `https://backpack.tf/api/${path}`,
+        url: `https://api.backpack.tf/api/${path}`,
         ...(as === 'data'
           ? { data: { ...payload, ...authStore } }
           : { params: { ...payload, ...authStore }  }),
@@ -122,7 +122,7 @@ export class BackpackTFAPI {
 
     return this.requestClient.send<T>({
       method,
-      url: `https://backpack.tf/api/${path}`,
+      url: `https://api.backpack.tf/api/${path}`,
       params: {
         ...payload,
         ...authStore,


### PR DESCRIPTION
Due to the new next page coming up fisk has asked us to start using api.backpack.tf instead to dodge unnecessary proxying that will happen when next is done.