### PR TITLE
feat: add missing update batch endpoint and get batch limit endpoint

### DIFF
--- a/src/backpack-tf.ts
+++ b/src/backpack-tf.ts
@@ -30,6 +30,7 @@ import {
 import {
   constructDeleteAllListingsParams,
   UpdateListing,
+  UpdateListingParam,
 } from './params/classifieds-v2';
 import { DeleteListingsResponse } from './responses/delete-listings';
 import { CreateListingsResponse } from './responses/create-listings';
@@ -57,6 +58,8 @@ import {
   GetListingsResponse,
   V2Listing,
   CreateListingBatchResponse,
+  UpdateListingBatchResponse,
+  GetBatchOperationLimitResponse,
 } from './responses/classifieds-v2';
 import { LimitsResponse } from './responses/limits';
 import { Intent } from './common';
@@ -452,6 +455,25 @@ export class BackpackTFAPI {
       auth: 'token',
       payload: params.map(constructV2CreateListingParams),
       as: 'data'
+    });
+  }
+
+  getBatchOperationLimit() {
+    return this.request<GetBatchOperationLimitResponse>('GET', 'v2/classifieds/listings/batch', {
+      auth: 'token',
+      as: 'params',
+    });
+  }
+
+  /**
+   * Undocumented V2 api for updating multiple listings in one request.
+   * Does not support archived listings.
+   */
+  updateListingsBatch(params: UpdateListingParam[]) {
+    return this.request<UpdateListingBatchResponse[]>('PATCH', 'v2/classifieds/listings/batch', {
+      auth: 'token',
+      payload: params,
+      as: 'params'
     });
   }
 

--- a/src/params/classifieds-v2.ts
+++ b/src/params/classifieds-v2.ts
@@ -1,6 +1,11 @@
 import { Intent } from '../common';
 import { Currencies } from '../responses/common';
 
+export type UpdateListingParam = {
+  id: string;
+  body: UpdateListing;
+};
+
 export type UpdateListing = {
   currencies?: Currencies;
   details?: string;

--- a/src/responses/classifieds-v2.ts
+++ b/src/responses/classifieds-v2.ts
@@ -62,3 +62,18 @@ export type CreateListingBatchResponse = (
   | FailedCreateListingResponse
   | SuccessCreateListingResponse
 )[];
+
+export type UpdateListingBatchResponse = {
+  errors: UpdateListingBatchError[];
+  updated: V2Listing[];
+};
+
+export type UpdateListingBatchError = {
+  index: number;
+  id: string;
+  message: string;
+};
+
+export type GetBatchOperationLimitResponse = {
+  opLimit: number;
+};


### PR DESCRIPTION
Adds two missing endpoints, one for updating active listings in batch and one for getting the batch operation limit for v2 batch endpoints.